### PR TITLE
Add Ingredients Analysis button to single product edit page

### DIFF
--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -906,13 +906,18 @@ content: " — ";
 	//Copy data from the language specific ingredients_text to the ingredients_text in the hidden form so it can be poassed to the analyser
 	function Copydata(){
 		var lang = $('ul#tabs_ingredients_image > li.active').attr("data-language");
+
 		console.log("Lang:" + lang);
 		var cd = $("#ingredients_text_"+lang).val();
-		console.log("Language Text:"+cd);
+		//console.log("Language Text:"+cd);
+
+        //Here we have to manipulate the language for regional languages
+        if(lang == 'ca'){lang = 'es-ca';} //Catalan
 
 		//As target language can be different from the page language we have to create the full URL
 		var URL = "http:/" + lang + ".openfoodfacts.org/cgi/test_ingredients_analysis.pl";
 		//analyse_form.setAttribute("action", "/cgi/test_ingredients_analysis.pl");
+        //console.log("analyse url="+URL);
 		analyse_form.setAttribute("action", URL);
 	  $("#ingredients_text").val(cd);
 	}

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -1500,7 +1500,7 @@ content: " — ";
         return originalArray;
     }
 
-
+ 
     /**
      * replaceInsideArray: replace some content by another in each string of an array
      * @example  finalArray = replaceInsideArray(["en:tomatoes","en:eggs"], /en:/, '');

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -906,13 +906,15 @@ content: " — ";
 	//Copy data from the language specific ingredients_text to the ingredients_text in the hidden form so it can be poassed to the analyser
 	function Copydata(){
 		var lang = $('ul#tabs_ingredients_image > li.active').attr("data-language");
+        var pageLanguage = $("html").attr('lang');      // Get page language
 
-		console.log("Lang:" + lang);
+		//console.log("Lang:" + lang);
 		var cd = $("#ingredients_text_"+lang).val();
 		//console.log("Language Text:"+cd);
 
         //Here we have to manipulate the language for regional languages
         if(lang == 'ca'){lang = 'es-ca';} //Catalan
+        if(lang == 'en'){lang = pageLanguage + '-en';} //English from source language page
 
 		//As target language can be different from the page language we have to create the full URL
 		var URL = "http:/" + lang + ".openfoodfacts.org/cgi/test_ingredients_analysis.pl";

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -913,8 +913,16 @@ content: " — ";
 		//console.log("Language Text:"+cd);
 
         //Here we have to manipulate the language for regional languages
-        if(lang == 'ca'){lang = 'es-ca';} //Catalan
-        if(lang == 'en'){lang = pageLanguage + '-en';} //English from source language page
+        if(lang === 'ca'){lang = 'es-ca';} //Catalan
+        if(lang === 'en'){
+            if(pageLanguage === 'en'){
+                lang = 'uk';//English
+            }
+            else
+            {
+                lang = pageLanguage + '-en'; //English from source language page
+            }
+        }
 
 		//As target language can be different from the page language we have to create the full URL
 		var URL = "http:/" + lang + ".openfoodfacts.org/cgi/test_ingredients_analysis.pl";

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -33,25 +33,6 @@
 // * Tagify 3.6.3, in replacement of jQuery-Tags-Input 1.3.6 (no more maintained)
 //   https://github.com/yairEO/tagify
 
-//Hidden form for ingredients analysis
-//Ingredients analysis takes its input from 'ingredients_text' but the language pages have the text in 'ingredients_text_xx'
-//so we have to copy the text (in Copytext) before submitting the form
-var analyse_form = document.createElement("form");
-analyse_form.setAttribute("method", "get");
-analyse_form.setAttribute("enctype", "multipart/form-data");//.openfoodfacts.org/cgi
-//analyse_form.setAttribute("action", "/cgi/test_ingredients_analysis.pl");
-var txt = document.createElement('textarea');
-txt.setAttribute('id', 'ingredients_text');
-txt.setAttribute('name', 'ingredients_text');
-txt.setAttribute('style', 'display:none;');
-var sub = document.createElement('input');
-sub.setAttribute('type', 'hidden');
-sub.setAttribute('name', 'action');
-sub.setAttribute('value', 'process');
-analyse_form.appendChild(txt);
-analyse_form.appendChild(sub);
-document.body.appendChild(analyse_form);
-
 (function() {
     'use strict';
 
@@ -614,6 +595,26 @@ content: " — ";
         });
 
         if (pageType === "edit"){
+
+            //Hidden form for ingredients analysis
+            //Ingredients analysis takes its input from 'ingredients_text' but the language pages have the text in 'ingredients_text_xx'
+            //so we have to copy the text (in Copytext) before submitting the form
+            var analyse_form = document.createElement("form");
+            analyse_form.setAttribute("method", "get");
+            analyse_form.setAttribute("enctype", "multipart/form-data");//.openfoodfacts.org/cgi
+            //analyse_form.setAttribute("action", "/cgi/test_ingredients_analysis.pl");
+            var txt = document.createElement('textarea');
+            txt.setAttribute('id', 'ingredients_text');
+            txt.setAttribute('name', 'ingredients_text');
+            txt.setAttribute('style', 'display:none;');
+            var sub = document.createElement('input');
+            sub.setAttribute('type', 'hidden');
+            sub.setAttribute('name', 'action');
+            sub.setAttribute('value', 'process');
+            analyse_form.appendChild(txt);
+            analyse_form.appendChild(sub);
+            document.body.appendChild(analyse_form);
+
             //Ingredients analysis check - opens in new window
             $('body').append('<button id="ing_analysis">Ingredients analysis</button>');
             $("#ing_analysis").click(function(){

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -474,7 +474,7 @@ content: " — ";
             console.log("href:" + href);
             var productCode = href.split("/")[2];
             console.log("productCode:" + productCode);
-            var url = "/cgi/product.pl?type=edit&code=" + productCode;
+            var url = "/cgi/product.pl?type=edit&code=" + productCode + '#tabs_ingredients_image';
             $('.products > li a').attr("href", url);
         });
     }

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -469,13 +469,15 @@ content: " — ";
 
     //Add a button to go straight to edit rather than the product page then edit
 	if (pageType === "list"){
-        $( ".products > li" ).each(function() {
-            var href = $('.products > li a').attr("href");//.attr("data-language");
-            console.log("href:" + href);
+        $( "ul.products > li a" ).each(function() {
+            var href = $(this).attr("href");
+            //console.log("href:" + href);
             var productCode = href.split("/")[2];
-            console.log("productCode:" + productCode);
-            var url = "/cgi/product.pl?type=edit&code=" + productCode + '#tabs_ingredients_image';
-            $('.products > li a').attr("href", url);
+            //console.log("productCode:" + productCode);
+            var url = '/cgi/product.pl?type=edit&code=' + productCode + '#tabs_ingredients_image';
+            //console.log("New URL:"+url);
+            $(this).attr("href", url); //Puts in ul/li
+            $(this).attr("target", "_blank");
         });
     }
 

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -586,14 +586,14 @@ content: " — ";
             toggleHelpers();
         });
 
-        //Ingredients analysis check - opens in new window
-        $('body').append('<button id="ing_analysis">Ingredients analysis</button>');
-        $("#ing_analysis").click(function(){
-           //console.log("analyse");
-           submitToPopup(analyse_form);
-        });
-
-
+        if (pageType === "edit"){
+            //Ingredients analysis check - opens in new window
+            $('body').append('<button id="ing_analysis">Ingredients analysis</button>');
+            $("#ing_analysis").click(function(){
+                //console.log("analyse");
+                submitToPopup(analyse_form);
+            });
+        }
 
         // Keyboard actions
         $(document).on('keydown', function(event) {

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -443,7 +443,15 @@ content: " — ";
             if(tds.length != 0) {
                 url = tds.eq(0).html();
             }
-            var url1 = url.replace('defined"','defined" target="_blank"');
+            var url1;
+            if(url.includes('defined')){
+                url1 = url.replace('defined"','defined" target="_blank"');
+               }
+            else
+            {
+                url1 = url.replace('known"','known" target="_blank"');
+            }
+            console.log("url1="+url1);
             $(this).find('td').eq(2).after('<td style="width:400px">"' + url1 + '"</td>');
         });
     }

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -33,6 +33,25 @@
 // * Tagify 3.6.3, in replacement of jQuery-Tags-Input 1.3.6 (no more maintained)
 //   https://github.com/yairEO/tagify
 
+//Hidden form for ingredients analysis
+//Ingredients analysis takes its input from 'ingredients_text' but the language pages have the text in 'ingredients_text_xx'
+//so we have to copy the text (in Copytext) before submitting the form
+var analyse_form = document.createElement("form");
+analyse_form.setAttribute("method", "get");
+analyse_form.setAttribute("enctype", "multipart/form-data");//.openfoodfacts.org/cgi
+//analyse_form.setAttribute("action", "/cgi/test_ingredients_analysis.pl");
+var txt = document.createElement('textarea');
+txt.setAttribute('id', 'ingredients_text');
+txt.setAttribute('name', 'ingredients_text');
+txt.setAttribute('style', 'display:none;');
+var sub = document.createElement('input');
+sub.setAttribute('type', 'hidden');
+sub.setAttribute('name', 'action');
+sub.setAttribute('value', 'process');
+analyse_form.appendChild(txt);
+analyse_form.appendChild(sub);
+document.body.appendChild(analyse_form);
+
 (function() {
     'use strict';
 
@@ -320,6 +339,16 @@ background-color:red;
 border-radius: 0 10px 10px 0;
 }
 
+#ing_analysis {
+position:fixed;
+left:0%;
+top:5rem;
+padding:0 0.7rem 0 0.7rem;
+font-size:1.5rem;
+background-color:red;
+border-radius: 0 10px 10px 0;
+}
+
 /* Let nutrition image as tall as Nutrition facts table */
 #nutrition_image_copy {
 width: 80%;
@@ -555,6 +584,13 @@ content: " — ";
         $("#pwe_help").click(function(){
             showPowerUserInfo(help);
             toggleHelpers();
+        });
+
+        //Ingredients analysis check - opens in new window
+        $('body').append('<button id="ing_analysis">Ingredients analysis</button>');
+        $("#ing_analysis").click(function(){
+           //console.log("analyse");
+           submitToPopup(analyse_form);
         });
 
 
@@ -838,9 +874,27 @@ content: " — ";
 
     }
 
+	//Copy data from the language specific ingredients_text to the ingredients_text in the hidden form so it can be poassed to the analyser
+	function Copydata(){
+		var lang = $('ul#tabs_ingredients_image > li.active').attr("data-language");
+		console.log("Lang:" + lang);
+		var cd = $("#ingredients_text_"+lang).val();
+		console.log("Language Text:"+cd);
 
+		//As target language can be different from the page language we have to create the full URL
+		var URL = "http:/" + lang + ".openfoodfacts.org/cgi/test_ingredients_analysis.pl";
+		//analyse_form.setAttribute("action", "/cgi/test_ingredients_analysis.pl");
+		analyse_form.setAttribute("action", URL);
+	  $("#ingredients_text").val(cd);
+	}
 
-
+	function submitToPopup(f) {
+		console.log("submitToPopup");
+		Copydata();
+		var w = window.open('', 'form-target', 'width=800','height=800');
+		f.target = 'form-target';
+		f.submit();
+	}
 
     /***
      * listByRows

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -235,6 +235,7 @@ document.body.appendChild(analyse_form);
 	margin: .5em .4em .5em 0;
 	cursor: pointer;
 }
+
 .ui-dialog .ui-resizable-n {
 	height: 2px;
 	top: 0;
@@ -453,6 +454,30 @@ content: " — ";
         );
     }
 
+    //Add button to ingredient so it opens in a new window
+    if (pageType === "ingredients"){
+        $('#tagstable').find('tr').each(function(){
+            var tds = $(this).find('td');
+            var url = "";
+            if(tds.length != 0) {
+                url = tds.eq(0).html();
+            }
+            var url1 = url.replace('defined"','defined" target="_blank"');
+            $(this).find('td').eq(2).after('<td style="width:400px">"' + url1 + '"</td>');
+        });
+    }
+
+    //Add a button to go straight to edit rather than the product page then edit
+	if (pageType === "list"){
+        $( ".products > li" ).each(function() {
+            var href = $('.products > li a').attr("href");//.attr("data-language");
+            console.log("href:" + href);
+            var productCode = href.split("/")[2];
+            console.log("productCode:" + productCode);
+            var url = "/cgi/product.pl?type=edit&code=" + productCode;
+            $('.products > li a').attr("href", url);
+        });
+    }
 
     // ***
     // * Every mode, except "api", "list", "search-form"
@@ -594,6 +619,8 @@ content: " — ";
                 submitToPopup(analyse_form);
             });
         }
+
+
 
         // Keyboard actions
         $(document).on('keydown', function(event) {
@@ -1383,6 +1410,11 @@ content: " — ";
         // Detect recentchanges
         regex_search = RegExp('cgi/recent_changes.pl');
         if(regex_search.test(document.URL) === true) return "recent changes";
+
+        //Detect if in the list of ingredients
+        regex_search = RegExp('ingredients');
+        if(regex_search.test(document.URL) === true) return "ingredients";
+
 
         // Finally, it's a product view
         if($("body").attr("typeof") === "food:foodProduct") return "product view";


### PR DESCRIPTION
This adds several updates to the script. Having edited loads of products it addresses some of the shortcomings I have found and makes life so much easier :-)

- On the list of ingredients , adds a column to the table with the ingredient. Clicking this opens the ingredient list in a new window. This resolves the problem of a long wait when there are loads of programs and the alternative of having to right-click and open in new window.

- When in the list of products, clicking on the product goes directly to the opened edit window so you don't have to open the product then click edit. It opens the product editor in a new window.

- Add a button to send the list of ingredients to the ingredients analysis page for the language selected for the ingredients when the page is in 'Edit'.