### PR TITLE
feat: edit_shortcut_from_save-product_page

### DIFF
--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -2,7 +2,7 @@
 // @name        Open Food Facts power user script
 // @description Helps power users in their day to day work. Key "?" shows help. This extension is a kind of sandbox to experiment features that could be added to Open Food Facts website.
 // @namespace   openfoodfacts.org
-// @version     2023-09-15T22:59
+// @version     2023-10-11T09:43
 // @include     https://*.openfoodfacts.org/*
 // @include     https://*.openproductsfacts.org/*
 // @include     https://*.openbeautyfacts.org/*
@@ -59,7 +59,7 @@
     var proPlatform = false;     // TODO: to be included in isPageType()
     const pageType = isPageType(); // test page type
     const corsProxyURL = "";
-    log("2023-09-15T22:59 - mode: " + pageType);
+    log("2023-10-11T09:43 - mode: " + pageType);
 
     // Disable extension if the page is an API result; https://world.openfoodfacts.org/api/v0/product/3222471092705.json
     if (pageType === "api") {

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -790,7 +790,7 @@ textarea.monospace {
                     return;
                 }
                 // (e): edit current product in current window
-                if (pageType === "product view" && event.key === 'e') {
+                if ((pageType === "product view" || pageType === "saved-product page") && event.key === 'e') {
                     window.open(editURL, "_self"); // edit in current window
                     return;
                 }


### PR DESCRIPTION
### What
allow "e" shortcut to reedit saved product saved-product page, without going to product view page
Helpful when you run tests locally (save, look at the logs, edit, save, edit, save edit)