### PR TITLE
Bugfix: Not all barcodes are being drawn JsBarcode.

### DIFF
--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -1705,15 +1705,20 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
                     break;
             }
 
-            JsBarcode("#barcode_draw_" + code, code, {
-                format: barcode_format,
-                flat: true,
-                fontSize: 10,
-                lineColor: "black",
-                width: 1,
-                height: 40,
-                displayValue: true,
-            });
+			try {            
+				JsBarcode("#barcode_draw_" + code, code, {
+					format: barcode_format,
+					flat: true,
+					fontSize: 10,
+					lineColor: "black",
+					width: 1,
+					height: 40,
+					displayValue: true,
+				});
+			}catch(error){
+                console.error(error);
+            }
+
 
             $('a.list_product_a', this).addClass('with_barcode');
         });

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -1705,17 +1705,17 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
                     break;
             }
 
-			try {            
-				JsBarcode("#barcode_draw_" + code, code, {
-					format: barcode_format,
-					flat: true,
-					fontSize: 10,
-					lineColor: "black",
-					width: 1,
-					height: 40,
-					displayValue: true,
-				});
-			}catch(error){
+             try {            
+                JsBarcode("#barcode_draw_" + code, code, {
+                    format: barcode_format,
+                    flat: true,
+                    fontSize: 10,
+                    lineColor: "black",
+                    width: 1,
+                    height: 40,
+                    displayValue: true,
+                });
+            }catch(error){
                 console.error(error);
             }
 


### PR DESCRIPTION
### What
When you want to show barcodes (shift+b) JSBarcode sometimes throws an error similar to 

`"2000000148223" is not a valid input for e`

Since the barcodes are being drawn inside a for loop one by one, eventually an exeption occurs and quits the for loop leaving the remaining barcodes not drawn:

### Screenshot
![image](https://github.com/openfoodfacts/power-user-script/assets/22033222/06963fa5-50e6-4366-a299-1397b1f3426a)

All I do is add a try{}catch(){} block. I dont fix the error itself. I am guessing the barcode is not a valid format therefore it is not being drawn by JsBarcode.
