### PR TITLE
feat: Hide edit fields in product edit

### DIFF
--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -1502,7 +1502,7 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
         }
     }
     
-    
+    // Hide Text Fields
      function toggleHideTextFieldsPopUp() {
          if($("#power-user-hide-fields-popup").dialog("isOpen") === true){
              $("#power-user-hide-fields-popup").dialog("close");
@@ -1520,6 +1520,8 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
          var popUpContent = getPowerUserHideFieldsContent();
             
         $("#power-user-hide-fields-popup").html(popUpContent);
+
+        getHideFieldsCheckboxesFromStorage();
             
         let popup = $("#power-user-hide-fields-popup").dialog({
             autoOpen: true,
@@ -1530,47 +1532,116 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
      
      function getPowerUserHideFieldsContent(){
          return `<ul class="pus_hide_menu">
-         <li>`+ getInputWithCheckbox('Hide misc card','test2','test3') + `
-         <ul><li>`+ getInputWithCheckbox('Barcode not correct','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Product taken off the market','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Withdrawal date','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Alert boxes','test2','test3') + `</li></ul>
+         <li>`+ createInputWithCheckbox('Hide misc card','pus-hide-misc-card') + `
+         <ul><li>`+ createInputWithCheckbox('Barcode not correct','pus-hide-barcode-not-correct') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Product taken off the market','pus-hide-product-taken-off') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Withdrawal date','pus-hide-withdrawal-date') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Alert boxes','pus-hide-alert-boxes') + `</li></ul>
          </li>
          <hr>
-         <li>`+ getInputWithCheckbox('Hide product picture card','test2','test3') + `</li>
+         <li>`+ createInputWithCheckbox('Hide product picture card','pus-hide-product-picture') + `</li>
          <hr>
-         <li>`+ getInputWithCheckbox('Hide product characteristics card','test2','test3') + `
-         <ul><li>`+ getInputWithCheckbox('Product name','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Common name','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Quantity','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Brands','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Categories','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Labels, certifications, awards','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Manufacturing or processing places','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Traceability code','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Link to the product page...','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Best before date','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('City, state and country ','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Stores','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Countries where sold','test2','test3') + `</li></ul>
+         <li>`+ createInputWithCheckbox('Hide product characteristics card','pus-hide-product-char') + `
+         <ul><li>`+ createInputWithCheckbox('Product name','pus-hide-product-name') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Common name','pus-hide-common-name') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Quantity','pus-hide-quantity') + `</li></ul>
+         
+         <ul><li>`+ createInputWithCheckbox('Link to the product page...','pus-hide-link-to-product') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Best before date','pus-hide-best-before') + `</li></ul>
          </li>
          <hr>
-         <li>`+ getInputWithCheckbox('Hide ingredients card','test2','test3') + `
-         <ul><li>`+ getInputWithCheckbox('Origin of the product ','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Substances or products...','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Traces','test2','test3') + `</li></ul>
-         <ul><li>`+ getInputWithCheckbox('Origin of ingredients','test2','test3') + `</li></ul>
+         <li>`+ createInputWithCheckbox('Hide ingredients card','pus-hide-ingredients') + `
+         <ul><li>`+ createInputWithCheckbox('Origin of the product ','pus-hide-origin-product') + `</li></ul>
+         
          </li>
          <hr>
-         <li>`+ getInputWithCheckbox('Hide nutrition card','test2','test3') + `</li>
+         <li>`+ createInputWithCheckbox('Hide nutrition card','pus-hide-nutrition') + `</li>
          <hr>
-         <li>`+ getInputWithCheckbox('Hide packaging card','test2','test3') + `</li>
+         <li>`+ createInputWithCheckbox('Hide packaging card','pus-hide-packaging') + `</li>
         </ul>`;
+
+        /** Cant hide because of tags having no id
+         * <ul><li>`+ createInputWithCheckbox('Brands','pus-hide-brands') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Categories','pus-hide-categories') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Labels, certifications, awards','pus-hide-labels') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Manufacturing or processing places','pus-hide-manufactoring') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Traceability code','pus-hide-traceability') + `</li></ul>
+         * 
+          <ul><li>`+ createInputWithCheckbox('City, state and country ','pus-hide-city-state') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Stores','pus-hide-stores') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Countries where sold','pus-hide-countries-sold') + `</li></ul>
+
+         <ul><li>`+ createInputWithCheckbox('Substances or products...','pus-hide-substances') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Traces','pus-hide-traces') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Origin of ingredients','pus-hide-origin-ingredients') + `</li></ul>
+         */
      }
      
-     function getInputWithCheckbox(labelValue, inputClass, inputId){
-         return '<input class="'+inputClass+'" type="checkbox" id="'+inputId+'"><label for="'+inputId+'">'+labelValue+'</label>';
+     //generetes an input and also manages, stores, retrieves the checked state.
+     function createInputWithCheckbox(labelValue, inputId){
+         let checkbox = '<input type="checkbox" id="'+inputId+'"><label for="'+inputId+'">'+labelValue+'</label>';
+         return checkbox
      }
+
+     function getHideFieldsCheckboxesFromStorage(){
+        getHideFieldCheckboxFromStorage('pus-hide-misc-card',['#misc']);
+        getHideFieldCheckboxFromStorage('pus-hide-barcode-not-correct',['#label_new_code','#new_code']);
+        getHideFieldCheckboxFromStorage('pus-hide-product-taken-off',['#obsolete','label[for="obsolete"]']);
+        getHideFieldCheckboxFromStorage('pus-hide-withdrawal-date',['#obsolete_since_date','label[for="obsolete_since_date"]']);
+        getHideFieldCheckboxFromStorage('pus-hide-alert-boxes',['#warning_3rd_party_content','#licence_accept']);
+        getHideFieldCheckboxFromStorage('pus-hide-product-picture',['#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-product-char',['#product_characteristics']);
+        getHideFieldCheckboxFromStorage('pus-hide-product-name',['[id^="product_name_"]','label[for^="product_name_"]']);
+        getHideFieldCheckboxFromStorage('pus-hide-common-name',['[id^="generic_name_"]','label[for^="generic_name_"]']);
+        getHideFieldCheckboxFromStorage('pus-hide-quantity',['#quantity','label[for="quantity"]']);
+        //getHideFieldCheckboxFromStorage('pus-hide-brands',['tags','label[for="brands"]']);
+        //getHideFieldCheckboxFromStorage('pus-hide-categories',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-labels',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-manufactoring',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-traceability',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-link-to-product',['#link','label[for="link"]']);
+        getHideFieldCheckboxFromStorage('pus-hide-best-before',['#expiration_date','label[for="expiration_date"]']);
+        //getHideFieldCheckboxFromStorage('pus-hide-city-state',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-stores',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-countries-sold',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-ingredients',['#ingredients']);
+        getHideFieldCheckboxFromStorage('pus-hide-origin-product',['[id^="origin_"]','label[for^="origin_"]']);
+        //getHideFieldCheckboxFromStorage('pus-hide-substances',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-traces',['#misc','#product_image']);
+        //getHideFieldCheckboxFromStorage('pus-hide-origin-ingredients',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-nutrition',['#nutrition']);
+        getHideFieldCheckboxFromStorage('pus-hide-packaging',['#packaging_section']);
+     }
+
+     function getHideFieldCheckboxFromStorage(checkboxId,hideFieldsIds){
+        if(getLocalStorage(checkboxId) === "checked"){
+            $('#'+checkboxId).prop("checked", true);
+        }
+        
+        $('#'+checkboxId).change(function() {
+            if(this.checked){
+                 localStorage.setItem(checkboxId, "checked");
+            }else{
+                 localStorage.setItem(checkboxId, "unchecked");
+            }
+            toggleHideField(hideFieldsIds);
+        });
+     }
+
+     function toggleHideField(hideFieldsIds){
+        $.each(hideFieldsIds,function(index,element){
+            if($(element).hasClass('pus-hide-content')){
+                $(element).removeClass('pus-hide-content');
+                $(element).show();
+            }else{
+                $(element).addClass('pus-hide-content');
+                $(element).hide();
+            }
+        });
+        
+        
+     }
+     // END OF Hide Text Fields
 
 
     function toggleIngredientsMode() {

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -779,7 +779,7 @@ textarea.monospace {
             });
             
             $('body').append('<button id="pwe_hide_text_fields">Hide fields</button>');
-            $("#pwe_help").click(function(){
+            $("#pwe_hide_text_fields").click(function(){
                 toggleHideTextFieldsPopUp();
             });
         }
@@ -1491,7 +1491,7 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
         //$("#power-user-help").prev().addClass('ui-state-information');
         return popup;
     }
-
+    
     // Toggle popup
     function togglePowerUserInfo(message) {
         if ($("#power-user-help").dialog( "isOpen" ) === true) {
@@ -1503,7 +1503,74 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
     }
     
     
-
+     function toggleHideTextFieldsPopUp() {
+         if($("#power-user-hide-fields-popup").dialog("isOpen") === true){
+             $("#power-user-hide-fields-popup").dialog("close");
+         }else{
+             return showPowerUserHideTextFieldsPopUp();
+         }
+     }
+     
+     function showPowerUserHideTextFieldsPopUp(){
+        if($("#power-user-hide-fields-popup").length === 0){
+            $('body').append('<div id="power-user-hide-fields-popup" title="Hide text fields"></div>');
+            $("#power-user-hide-fields-popup").dialog({autoOpen: false});
+        }
+        
+         var popUpContent = getPowerUserHideFieldsContent();
+            
+        $("#power-user-hide-fields-popup").html(popUpContent);
+            
+        let popup = $("#power-user-hide-fields-popup").dialog({
+            autoOpen: true,
+            width: 400,
+            dialogClass: 'dialogstyleperso',
+        }); 
+    }
+     
+     function getPowerUserHideFieldsContent(){
+         return `<ul class="pus_hide_menu">
+         <li>`+ getInputWithCheckbox('Hide misc card','test2','test3') + `
+         <ul><li>`+ getInputWithCheckbox('Barcode not correct','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Product taken off the market','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Withdrawal date','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Alert boxes','test2','test3') + `</li></ul>
+         </li>
+         <hr>
+         <li>`+ getInputWithCheckbox('Hide product picture card','test2','test3') + `</li>
+         <hr>
+         <li>`+ getInputWithCheckbox('Hide product characteristics card','test2','test3') + `
+         <ul><li>`+ getInputWithCheckbox('Product name','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Common name','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Quantity','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Brands','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Categories','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Labels, certifications, awards','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Manufacturing or processing places','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Traceability code','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Link to the product page...','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Best before date','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('City, state and country ','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Stores','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Countries where sold','test2','test3') + `</li></ul>
+         </li>
+         <hr>
+         <li>`+ getInputWithCheckbox('Hide ingredients card','test2','test3') + `
+         <ul><li>`+ getInputWithCheckbox('Origin of the product ','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Substances or products...','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Traces','test2','test3') + `</li></ul>
+         <ul><li>`+ getInputWithCheckbox('Origin of ingredients','test2','test3') + `</li></ul>
+         </li>
+         <hr>
+         <li>`+ getInputWithCheckbox('Hide nutrition card','test2','test3') + `</li>
+         <hr>
+         <li>`+ getInputWithCheckbox('Hide packaging card','test2','test3') + `</li>
+        </ul>`;
+     }
+     
+     function getInputWithCheckbox(labelValue, inputClass, inputId){
+         return '<input class="'+inputClass+'" type="checkbox" id="'+inputId+'"><label for="'+inputId+'">'+labelValue+'</label>';
+     }
 
 
     function toggleIngredientsMode() {

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -1547,13 +1547,23 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
          <ul><li>`+ createInputWithCheckbox('Product name','pus-hide-product-name') + `</li></ul>
          <ul><li>`+ createInputWithCheckbox('Common name','pus-hide-common-name') + `</li></ul>
          <ul><li>`+ createInputWithCheckbox('Quantity','pus-hide-quantity') + `</li></ul>
-         
+         <ul><li>`+ createInputWithCheckbox('Brands','pus-hide-brands') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Categories','pus-hide-categories') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Labels, certifications, awards','pus-hide-labels') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Manufacturing or processing places','pus-hide-manufactoring') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Traceability code','pus-hide-traceability') + `</li></ul>
          <ul><li>`+ createInputWithCheckbox('Link to the product page...','pus-hide-link-to-product') + `</li></ul>
          <ul><li>`+ createInputWithCheckbox('Best before date','pus-hide-best-before') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('City, state and country ','pus-hide-city-state') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Stores','pus-hide-stores') + `</li></ul>
+          <ul><li>`+ createInputWithCheckbox('Countries where sold','pus-hide-countries-sold') + `</li></ul>
          </li>
          <hr>
          <li>`+ createInputWithCheckbox('Hide ingredients card','pus-hide-ingredients') + `
          <ul><li>`+ createInputWithCheckbox('Origin of the product ','pus-hide-origin-product') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Substances or products...','pus-hide-substances') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Traces','pus-hide-traces') + `</li></ul>
+         <ul><li>`+ createInputWithCheckbox('Origin of ingredients','pus-hide-origin-ingredients') + `</li></ul>
          
          </li>
          <hr>
@@ -1561,22 +1571,6 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
          <hr>
          <li>`+ createInputWithCheckbox('Hide packaging card','pus-hide-packaging') + `</li>
         </ul>`;
-
-        /** Cant hide because of tags having no id
-         * <ul><li>`+ createInputWithCheckbox('Brands','pus-hide-brands') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Categories','pus-hide-categories') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Labels, certifications, awards','pus-hide-labels') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Manufacturing or processing places','pus-hide-manufactoring') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Traceability code','pus-hide-traceability') + `</li></ul>
-         * 
-          <ul><li>`+ createInputWithCheckbox('City, state and country ','pus-hide-city-state') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Stores','pus-hide-stores') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Countries where sold','pus-hide-countries-sold') + `</li></ul>
-
-         <ul><li>`+ createInputWithCheckbox('Substances or products...','pus-hide-substances') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Traces','pus-hide-traces') + `</li></ul>
-         <ul><li>`+ createInputWithCheckbox('Origin of ingredients','pus-hide-origin-ingredients') + `</li></ul>
-         */
      }
      
      //generetes an input and also manages, stores, retrieves the checked state.
@@ -1596,26 +1590,26 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
         getHideFieldCheckboxFromStorage('pus-hide-product-name',['[id^="product_name_"]','label[for^="product_name_"]']);
         getHideFieldCheckboxFromStorage('pus-hide-common-name',['[id^="generic_name_"]','label[for^="generic_name_"]']);
         getHideFieldCheckboxFromStorage('pus-hide-quantity',['#quantity','label[for="quantity"]']);
-        //getHideFieldCheckboxFromStorage('pus-hide-brands',['tags','label[for="brands"]']);
-        //getHideFieldCheckboxFromStorage('pus-hide-categories',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-labels',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-manufactoring',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-traceability',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-brands',['label[for="brands"]','label[for="brands"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-categories',['label[for="categories"]','label[for="categories"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-labels',['label[for="labels"]','label[for="labels"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-manufactoring',['label[for="manufacturing_places"]','label[for="manufacturing_places"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-traceability',['label[for="emb_codes"]','label[for="emb_codes"]'],true); 
         getHideFieldCheckboxFromStorage('pus-hide-link-to-product',['#link','label[for="link"]']);
         getHideFieldCheckboxFromStorage('pus-hide-best-before',['#expiration_date','label[for="expiration_date"]']);
-        //getHideFieldCheckboxFromStorage('pus-hide-city-state',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-stores',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-countries-sold',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-city-state',['label[for="purchase_places"]','label[for="purchase_places"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-stores',['label[for="stores"]','label[for="stores"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-countries-sold',['label[for="countries"]','label[for="countries"]'],true);
         getHideFieldCheckboxFromStorage('pus-hide-ingredients',['#ingredients']);
         getHideFieldCheckboxFromStorage('pus-hide-origin-product',['[id^="origin_"]','label[for^="origin_"]']);
-        //getHideFieldCheckboxFromStorage('pus-hide-substances',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-traces',['#misc','#product_image']);
-        //getHideFieldCheckboxFromStorage('pus-hide-origin-ingredients',['#misc','#product_image']);
+        getHideFieldCheckboxFromStorage('pus-hide-substances',['label[for="allergens"]','label[for="allergens"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-traces',['label[for="traces"]','label[for="traces"]'],true);
+        getHideFieldCheckboxFromStorage('pus-hide-origin-ingredients',['label[for="origins"]','label[for="origins"]'],true);
         getHideFieldCheckboxFromStorage('pus-hide-nutrition',['#nutrition']);
         getHideFieldCheckboxFromStorage('pus-hide-packaging',['#packaging_section']);
      }
 
-     function getHideFieldCheckboxFromStorage(checkboxId,hideFieldsIds){
+     function getHideFieldCheckboxFromStorage(checkboxId,hideFieldsIds,hasTags = false){
         if(getLocalStorage(checkboxId) === "checked"){
             $('#'+checkboxId).prop("checked", true);
         }
@@ -1626,18 +1620,21 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
             }else{
                  localStorage.setItem(checkboxId, "unchecked");
             }
-            toggleHideField(hideFieldsIds);
+            toggleHideField(hideFieldsIds,hasTags);
         });
      }
 
-     function toggleHideField(hideFieldsIds){
+     function toggleHideField(hideFieldsIds,hasTags = false){
+         //$("label[for='brands']").next().hide();
         $.each(hideFieldsIds,function(index,element){
-            if($(element).hasClass('pus-hide-content')){
-                $(element).removeClass('pus-hide-content');
-                $(element).show();
+            var elemen = element;
+            if(hasTags && index===1){ elemen = $(elemen).next();}
+            if($(elemen).hasClass('pus-hide-content')){
+                $(elemen).removeClass('pus-hide-content');
+                $(elemen).show();
             }else{
-                $(element).addClass('pus-hide-content');
-                $(element).hide();
+                $(elemen).addClass('pus-hide-content');
+                $(elemen).hide();
             }
         });
      }
@@ -1654,29 +1651,29 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
             loadHideTextFieldFromStorage('pus-hide-product-name',['[id^="product_name_"]','label[for^="product_name_"]']);
             loadHideTextFieldFromStorage('pus-hide-common-name',['[id^="generic_name_"]','label[for^="generic_name_"]']);
             loadHideTextFieldFromStorage('pus-hide-quantity',['#quantity','label[for="quantity"]']);
-            //loadHideTextFieldFromStorage('pus-hide-brands',['tags','label[for="brands"]']);
-            //loadHideTextFieldFromStorage('pus-hide-categories',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-labels',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-manufactoring',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-traceability',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-brands',['label[for="brands"]','label[for="brands"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-categories',['label[for="categories"]','label[for="categories"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-labels',['label[for="labels"]','label[for="labels"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-manufactoring',['label[for="manufacturing_places"]','label[for="manufacturing_places"]'],true); 
+            loadHideTextFieldFromStorage('pus-hide-traceability',['label[for="emb_codes"]','label[for="emb_codes"]'],true);
             loadHideTextFieldFromStorage('pus-hide-link-to-product',['#link','label[for="link"]']);
             loadHideTextFieldFromStorage('pus-hide-best-before',['#expiration_date','label[for="expiration_date"]']);
-            //loadHideTextFieldFromStorage('pus-hide-city-state',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-stores',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-countries-sold',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-city-state',['label[for="purchase_places"]','label[for="purchase_places"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-stores',['label[for="stores"]','label[for="stores"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-countries-sold',['label[for="countries"]','label[for="countries"]'],true);
             loadHideTextFieldFromStorage('pus-hide-ingredients',['#ingredients']);
             loadHideTextFieldFromStorage('pus-hide-origin-product',['[id^="origin_"]','label[for^="origin_"]']);
-            //loadHideTextFieldFromStorage('pus-hide-substances',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-traces',['#misc','#product_image']);
-            //loadHideTextFieldFromStorage('pus-hide-origin-ingredients',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-substances',['label[for="allergens"]','label[for="allergens"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-traces',['label[for="traces"]','label[for="traces"]'],true);
+            loadHideTextFieldFromStorage('pus-hide-origin-ingredients',['label[for="origins"]','label[for="origins"]'],true);
             loadHideTextFieldFromStorage('pus-hide-nutrition',['#nutrition']);
             loadHideTextFieldFromStorage('pus-hide-packaging',['#packaging_section']);
         });
           
     }
-    function loadHideTextFieldFromStorage(checkboxId, hideFieldsIds){
+    function loadHideTextFieldFromStorage(checkboxId, hideFieldsIds, hasTags = false){
         if(getLocalStorage(checkboxId) === "checked"){
-            toggleHideField(hideFieldsIds);
+            toggleHideField(hideFieldsIds,hasTags);
         }
     }
      // END OF Hide Text Fields

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -413,6 +413,17 @@ input.show_comparison {
     border-radius: 0 10px 10px 0;
     z-index: 200;
 }
+#pwe_hide_text_fields {
+    position:fixed;
+    left:0%;
+    top:8rem;
+    padding:0 0.7rem 0 0.7rem;
+    font-size:1.1rem;
+    background-color:red;
+    border-radius: 0 10px 10px 0;
+    z-index: 200;
+}
+
 /* ---------------- /Power User Script UI -------------------------- */
 
 
@@ -765,6 +776,11 @@ textarea.monospace {
                 //log("analyse");
                 Copydata();
                 submitToPopup(analyse_form);
+            });
+            
+            $('body').append('<button id="pwe_hide_text_fields">Hide fields</button>');
+            $("#pwe_help").click(function(){
+                toggleHideTextFieldsPopUp();
             });
         }
 
@@ -1476,7 +1492,6 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
         return popup;
     }
 
-
     // Toggle popup
     function togglePowerUserInfo(message) {
         if ($("#power-user-help").dialog( "isOpen" ) === true) {
@@ -1486,6 +1501,8 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
             return showPowerUserInfo(message);
         }
     }
+    
+    
 
 
 

--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -782,6 +782,8 @@ textarea.monospace {
             $("#pwe_hide_text_fields").click(function(){
                 toggleHideTextFieldsPopUp();
             });
+
+            loadHideTextFieldsFromStorage();
         }
 
 
@@ -1638,9 +1640,45 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
                 $(element).hide();
             }
         });
-        
-        
      }
+
+     function loadHideTextFieldsFromStorage(){
+        $( window ).on( "load", function() {
+            loadHideTextFieldFromStorage('pus-hide-misc-card',['#misc']);
+            loadHideTextFieldFromStorage('pus-hide-barcode-not-correct',['#label_new_code','#new_code']);
+            loadHideTextFieldFromStorage('pus-hide-product-taken-off',['#obsolete','label[for="obsolete"]']);
+            loadHideTextFieldFromStorage('pus-hide-withdrawal-date',['#obsolete_since_date','label[for="obsolete_since_date"]']);
+            loadHideTextFieldFromStorage('pus-hide-alert-boxes',['#warning_3rd_party_content','#licence_accept']);
+            loadHideTextFieldFromStorage('pus-hide-product-picture',['#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-product-char',['#product_characteristics']);
+            loadHideTextFieldFromStorage('pus-hide-product-name',['[id^="product_name_"]','label[for^="product_name_"]']);
+            loadHideTextFieldFromStorage('pus-hide-common-name',['[id^="generic_name_"]','label[for^="generic_name_"]']);
+            loadHideTextFieldFromStorage('pus-hide-quantity',['#quantity','label[for="quantity"]']);
+            //loadHideTextFieldFromStorage('pus-hide-brands',['tags','label[for="brands"]']);
+            //loadHideTextFieldFromStorage('pus-hide-categories',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-labels',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-manufactoring',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-traceability',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-link-to-product',['#link','label[for="link"]']);
+            loadHideTextFieldFromStorage('pus-hide-best-before',['#expiration_date','label[for="expiration_date"]']);
+            //loadHideTextFieldFromStorage('pus-hide-city-state',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-stores',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-countries-sold',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-ingredients',['#ingredients']);
+            loadHideTextFieldFromStorage('pus-hide-origin-product',['[id^="origin_"]','label[for^="origin_"]']);
+            //loadHideTextFieldFromStorage('pus-hide-substances',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-traces',['#misc','#product_image']);
+            //loadHideTextFieldFromStorage('pus-hide-origin-ingredients',['#misc','#product_image']);
+            loadHideTextFieldFromStorage('pus-hide-nutrition',['#nutrition']);
+            loadHideTextFieldFromStorage('pus-hide-packaging',['#packaging_section']);
+        });
+          
+    }
+    function loadHideTextFieldFromStorage(checkboxId, hideFieldsIds){
+        if(getLocalStorage(checkboxId) === "checked"){
+            toggleHideField(hideFieldsIds);
+        }
+    }
      // END OF Hide Text Fields
 
 
@@ -1808,7 +1846,6 @@ ul#products_match_all > li > a > span { display: table-cell; width:   70%;  vert
                 toggleListBarcodes();
             }
         });
-          
     }
 
 


### PR DESCRIPTION
### What
- Theres way too many fields when editing products. I figured hiding the ones that I dont need or rarely use is useful. It simplifies the product edit screen and lets me focus on adding specific data.
- Work in progress

### Screenshot
![image](https://github.com/openfoodfacts/power-user-script/assets/22033222/8b641839-862e-40ab-bee5-30e72d14b49b)

