### PR TITLE
feat: Include link to Open Prices on product pages

### DIFF
--- a/OpenFoodFactsPower.user.js
+++ b/OpenFoodFactsPower.user.js
@@ -2,7 +2,7 @@
 // @name        Open Food Facts power user script
 // @description Helps power users in their day to day work. Key "?" shows help. This extension is a kind of sandbox to experiment features that could be added to Open Food Facts website.
 // @namespace   openfoodfacts.org
-// @version     2024-12-20T11:15
+// @version     2025-05-28T10:01
 // @include     https://*.openfoodfacts.org/*
 // @include     https://*.openproductsfacts.org/*
 // @include     https://*.openbeautyfacts.org/*
@@ -64,7 +64,7 @@
     var proPlatform = false;     // TODO: to be included in isPageType()
     const pageType = isPageType(); // test page type
     const corsProxyURL = "";
-    log("2024-12-20T11:15 - mode: " + pageType);
+    log("2025-05-28T10:01 - mode: " + pageType);
 
     // Disable extension if the page is an API result; https://world.openfoodfacts.org/api/v0/product/3222471092705.json
     if (pageType === "api") {
@@ -705,6 +705,12 @@ textarea.monospace {
             $("#barcode_paragraph")
                 .append(' <span id="duckLink" class="productLink">[<a href="' + duckLink +
                         '">DDG</a>]');
+            // Link to Open Prices
+            var pricesLink = 'https://prices.openfoodfacts.org/app/products/' + code;
+            productExists(corsProxyURL+pricesLink,"#pricesLinkStatus","","");
+            $("#barcode_paragraph")
+                .append(' <span id="pricesLink" class="productLink">[<a href="' + pricesLink +
+                        '">prices</a>] (<span id="pricesLinkStatus"></span>)');
             // Link to Open Beauty Facts
             var obfLink = 'https://world.openbeautyfacts.org/product/' + code;
             productExists(corsProxyURL+obfLink,"#obfLinkStatus","","");


### PR DESCRIPTION
Adds a link to a product’s Open Prices product page in between DuckDuckGo search link and Open Beauty Facts lookup link.

![Shows the “prices” link among the other barcode line links.](https://github.com/user-attachments/assets/78738fdb-4df9-4090-93e2-c57b5251ec58)

Closes https://github.com/openfoodfacts/power-user-script/issues/87